### PR TITLE
ascociated error

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0.2"
-syn = "1.0"
+syn = { version = "1.0", features=["extra-traits", "parsing"]}
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/derive/src/de.rs
+++ b/derive/src/de.rs
@@ -2,15 +2,52 @@ use crate::{attr, bound};
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{
-    parse_quote, Data, DataEnum, DataStruct, DeriveInput, Error, Fields, FieldsNamed, Ident, Result,
+    parse_quote, Attribute, Data, DataEnum, DataStruct, DeriveInput, Error, Fields, FieldsNamed,
+    Ident, Lit, Meta, Result, Type,
 };
 
+#[derive(Default)]
+pub struct DeserConfig {
+    error_ty: Option<String>,
+}
+
+fn parse_config(attrs: &[Attribute]) -> Result<DeserConfig> {
+    let mut out = DeserConfig::default();
+    for attr in attrs {
+        let meta = attr.parse_meta()?;
+        if let Meta::List(list) = meta {
+            for nested in list.nested {
+                match nested {
+                    syn::NestedMeta::Lit(_) => todo!(),
+                    syn::NestedMeta::Meta(meta) => match meta {
+                        Meta::NameValue(nv) => {
+                            if nv.path.get_ident().unwrap().to_string() == "error" {
+                                match nv.lit {
+                                    Lit::Str(t) => {
+                                        out.error_ty.replace(t.value());
+                                    }
+                                    _ => todo!("blabla"),
+                                }
+                            }
+                        }
+                        Meta::List(_) => todo!("list"),
+                        Meta::Path(_) => todo!("path"),
+                    },
+                }
+            }
+        }
+    }
+
+    Ok(out)
+}
+
 pub fn derive(input: DeriveInput) -> Result<TokenStream> {
+    let conf = parse_config(&input.attrs)?;
     match &input.data {
         Data::Struct(DataStruct {
             fields: Fields::Named(fields),
             ..
-        }) => derive_struct(&input, fields),
+        }) => derive_struct(&input, fields, conf),
         Data::Enum(enumeration) => derive_enum(&input, enumeration),
         Data::Struct(_) => Err(Error::new(
             Span::call_site(),
@@ -23,7 +60,11 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
     }
 }
 
-pub fn derive_struct(input: &DeriveInput, fields: &FieldsNamed) -> Result<TokenStream> {
+pub fn derive_struct(
+    input: &DeriveInput,
+    fields: &FieldsNamed,
+    conf: DeserConfig,
+) -> Result<TokenStream> {
     let ident = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let dummy = Ident::new(
@@ -41,8 +82,12 @@ pub fn derive_struct(input: &DeriveInput, fields: &FieldsNamed) -> Result<TokenS
 
     let wrapper_generics = bound::with_lifetime_bound(&input.generics, "'__a");
     let (wrapper_impl_generics, wrapper_ty_generics, _) = wrapper_generics.split_for_impl();
+
     let bound = parse_quote!(miniserde::Deserialize);
     let bounded_where_clause = bound::where_clause_with_bound(&input.generics, bound);
+
+    let err_ty: Type =
+        syn::parse_str(dbg!(conf.error_ty.as_deref().unwrap_or("miniserde::Error")))?;
 
     Ok(quote! {
         #[allow(non_upper_case_globals)]
@@ -52,8 +97,8 @@ pub fn derive_struct(input: &DeriveInput, fields: &FieldsNamed) -> Result<TokenS
                 __out: miniserde::__private::Option<#ident #ty_generics>,
             }
 
-            impl #impl_generics miniserde::Deserialize for #ident #ty_generics #bounded_where_clause {
-                fn begin(__out: &mut miniserde::__private::Option<Self>) -> &mut dyn miniserde::de::Visitor {
+            impl #impl_generics miniserde::Deserialize<#err_ty> for #ident #ty_generics #bounded_where_clause {
+                fn begin(__out: &mut miniserde::__private::Option<Self>) -> &mut dyn miniserde::de::Visitor<#err_ty> {
                     unsafe {
                         &mut *{
                             __out
@@ -64,14 +109,38 @@ pub fn derive_struct(input: &DeriveInput, fields: &FieldsNamed) -> Result<TokenS
                 }
             }
 
-            impl #impl_generics miniserde::de::Visitor for __Visitor #ty_generics #bounded_where_clause {
-                fn map(&mut self) -> miniserde::Result<miniserde::__private::Box<dyn miniserde::de::Map + '_>> {
+            impl #impl_generics miniserde::de::Visitor<#err_ty> for __Visitor #ty_generics #bounded_where_clause {
+                fn map(&mut self) -> Result<miniserde::__private::Box<dyn miniserde::de::Map<#err_ty> + '_>, #err_ty> {
+
                     Ok(miniserde::__private::Box::new(__State {
                         #(
-                            #fieldname: miniserde::Deserialize::default(),
+                            #fieldname: miniserde::Deserialize::<#err_ty>::default(),
                         )*
                         __out: &mut self.__out,
                     }))
+                }
+            }
+
+            impl #wrapper_impl_generics miniserde::de::Map<#err_ty> for __State #wrapper_ty_generics #bounded_where_clause {
+                fn key(&mut self, __k: &miniserde::__private::str) -> Result<&mut dyn ::miniserde::de::Visitor<#err_ty>, #err_ty> {
+                    match __k {
+                        #(
+                            #fieldstr => miniserde::__private::Ok(miniserde::Deserialize::begin(&mut self.#fieldname)),
+                        )*
+                        _ => miniserde::__private::Ok(<dyn miniserde::de::Visitor<#err_ty>>::ignore()),
+                    }
+                }
+
+                fn finish(&mut self) -> Result<(), #err_ty> {
+                    #(
+                        let #fieldname = self.#fieldname.take().ok_or(#err_ty::unexpected())?;
+                    )*
+                    *self.__out = miniserde::__private::Some(#ident {
+                        #(
+                            #fieldname,
+                        )*
+                    });
+                    miniserde::__private::Ok(())
                 }
             }
 
@@ -82,31 +151,115 @@ pub fn derive_struct(input: &DeriveInput, fields: &FieldsNamed) -> Result<TokenS
                 __out: &'__a mut miniserde::__private::Option<#ident #ty_generics>,
             }
 
-            impl #wrapper_impl_generics miniserde::de::Map for __State #wrapper_ty_generics #bounded_where_clause {
-                fn key(&mut self, __k: &miniserde::__private::str) -> miniserde::Result<&mut dyn miniserde::de::Visitor> {
-                    match __k {
-                        #(
-                            #fieldstr => miniserde::__private::Ok(miniserde::Deserialize::begin(&mut self.#fieldname)),
-                        )*
-                        _ => miniserde::__private::Ok(<dyn miniserde::de::Visitor>::ignore()),
-                    }
-                }
-
-                fn finish(&mut self) -> miniserde::Result<()> {
-                    #(
-                        let #fieldname = self.#fieldname.take().ok_or(miniserde::Error)?;
-                    )*
-                    *self.__out = miniserde::__private::Some(#ident {
-                        #(
-                            #fieldname,
-                        )*
-                    });
-                    miniserde::__private::Ok(())
-                }
-            }
         };
     })
 }
+
+// pub fn derive_struct_default(input: &DeriveInput, fields: &FieldsNamed) -> Result<TokenStream> {
+//     let ident = &input.ident;
+//     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+//     let dummy = Ident::new(
+//         &format!("_IMPL_MINIDESERIALIZE_FOR_{}", ident),
+//         Span::call_site(),
+//     );
+//
+//     let fieldname = fields.named.iter().map(|f| &f.ident).collect::<Vec<_>>();
+//     let fieldty = fields.named.iter().map(|f| &f.ty);
+//     let fieldstr = fields
+//         .named
+//         .iter()
+//         .map(attr::name_of_field)
+//         .collect::<Result<Vec<_>>>()?;
+//
+//     let wrapper_generics = bound::with_lifetime_bound(&input.generics, "'__a");
+//     let (wrapper_impl_generics, wrapper_ty_generics, _) = wrapper_generics.split_for_impl();
+//
+//     let params = wrapper_generics
+//         .params
+//         .iter()
+//         .cloned()
+//         .chain(
+//             Some(GenericParam::Type(parse_quote!(
+//                 E: miniserde::de::VisitorError
+//             )))
+//             .into_iter(),
+//         )
+//         .collect();
+//
+//     let wrapper_generics_map = Generics {
+//         params,
+//         ..wrapper_generics.clone()
+//     };
+//     let (wrapper_impl_generics_map, _, _) = wrapper_generics_map.split_for_impl();
+//
+//     let bound = parse_quote!(miniserde::Deserialize);
+//     let bounded_where_clause = bound::where_clause_with_bound(&input.generics, bound);
+//
+//     Ok(quote! {
+//         #[allow(non_upper_case_globals)]
+//         const #dummy: () = {
+//             #[repr(C)]
+//             struct __Visitor #impl_generics #where_clause {
+//                 __out: miniserde::__private::Option<#ident #ty_generics>,
+//             }
+//
+//             impl<E: miniserde::de::VisitorError> #impl_generics miniserde::Deserialize<E> for #ident #ty_generics #bounded_where_clause {
+//                 fn begin(__out: &mut miniserde::__private::Option<Self>) -> &mut dyn miniserde::de::Visitor<E> {
+//                     unsafe {
+//                         &mut *{
+//                             __out
+//                             as *mut miniserde::__private::Option<Self>
+//                             as *mut __Visitor #ty_generics
+//                         }
+//                     }
+//                 }
+//             }
+//
+//             impl<E: miniserde::de::VisitorError> #impl_generics miniserde::de::Visitor<E> for __Visitor #ty_generics #bounded_where_clause {
+//                 fn map(&mut self) -> Result<miniserde::__private::Box<dyn miniserde::de::Map<E> + '_>, E> {
+//
+//                     Ok(miniserde::__private::Box::new(__State {
+//                         #(
+//                             #fieldname: miniserde::Deserialize::default(),
+//                         )*
+//                         __out: &mut self.__out,
+//                     }))
+//                 }
+//             }
+//
+//             impl #wrapper_impl_generics_map miniserde::de::Map<E> for __State #wrapper_ty_generics #bounded_where_clause {
+//                 fn key(&mut self, __k: &miniserde::__private::str) -> Result<&mut dyn ::miniserde::de::Visitor<E>, E> {
+//                     match __k {
+//                         #(
+//                             #fieldstr => miniserde::__private::Ok(miniserde::Deserialize::begin(&mut self.#fieldname)),
+//                         )*
+//                         _ => miniserde::__private::Ok(<dyn miniserde::de::Visitor<E>>::ignore()),
+//                     }
+//                 }
+//
+//                 fn finish(&mut self) -> Result<(), E> {
+//                     #(
+//                         let #fieldname = self.#fieldname.take().ok_or(E::unexpected())?;
+//                     )*
+//                     *self.__out = miniserde::__private::Some(#ident {
+//                         #(
+//                             #fieldname,
+//                         )*
+//                     });
+//                     miniserde::__private::Ok(())
+//                 }
+//             }
+//
+//             struct __State #wrapper_impl_generics #where_clause {
+//                 #(
+//                     #fieldname: miniserde::__private::Option<#fieldty>,
+//                 )*
+//                 __out: &'__a mut miniserde::__private::Option<#ident #ty_generics>,
+//             }
+//
+//         };
+//     })
+// }
 
 pub fn derive_enum(input: &DeriveInput, enumeration: &DataEnum) -> Result<TokenStream> {
     if input.generics.lt_token.is_some() || input.generics.where_clause.is_some() {

--- a/src/de/impls.rs
+++ b/src/de/impls.rs
@@ -1,5 +1,4 @@
 use crate::de::{Deserialize, Map, Seq, Visitor};
-use crate::error::{Error, Result};
 use crate::ignore::Ignore;
 use crate::ptr::NonuniqueBox;
 use crate::Place;
@@ -15,10 +14,12 @@ use std::collections::HashMap;
 #[cfg(feature = "std")]
 use std::hash::{BuildHasher, Hash};
 
-impl Deserialize for () {
-    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor {
-        impl Visitor for Place<()> {
-            fn null(&mut self) -> Result<()> {
+use super::VisitorError;
+
+impl<E: VisitorError> Deserialize<E> for () {
+    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor<E> {
+        impl<E: VisitorError> Visitor<E> for Place<()> {
+            fn null(&mut self) -> Result<(), E> {
                 self.out = Some(());
                 Ok(())
             }
@@ -27,10 +28,10 @@ impl Deserialize for () {
     }
 }
 
-impl Deserialize for bool {
-    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor {
-        impl Visitor for Place<bool> {
-            fn boolean(&mut self, b: bool) -> Result<()> {
+impl<E: VisitorError> Deserialize<E> for bool {
+    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor<E> {
+        impl<E: VisitorError> Visitor<E> for Place<bool> {
+            fn boolean(&mut self, b: bool) -> Result<(), E> {
                 self.out = Some(b);
                 Ok(())
             }
@@ -39,10 +40,10 @@ impl Deserialize for bool {
     }
 }
 
-impl Deserialize for String {
-    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor {
-        impl Visitor for Place<String> {
-            fn string(&mut self, s: &str) -> Result<()> {
+impl<E: VisitorError> Deserialize<E> for String {
+    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor<E> {
+        impl<E: VisitorError> Visitor<E> for Place<String> {
+            fn string(&mut self, s: &str) -> Result<(), E> {
                 self.out = Some(s.to_owned());
                 Ok(())
             }
@@ -53,24 +54,27 @@ impl Deserialize for String {
 
 macro_rules! signed {
     ($ty:ident) => {
-        impl Deserialize for $ty {
-            fn begin(out: &mut Option<Self>) -> &mut dyn Visitor {
-                impl Visitor for Place<$ty> {
-                    fn negative(&mut self, n: i64) -> Result<()> {
+        impl<E> Deserialize<E> for $ty
+        where
+            E: VisitorError,
+        {
+            fn begin(out: &mut Option<Self>) -> &mut dyn Visitor<E> {
+                impl<E: VisitorError> Visitor<E> for Place<$ty> {
+                    fn negative(&mut self, n: i64) -> Result<(), E> {
                         if n >= $ty::min_value() as i64 {
                             self.out = Some(n as $ty);
                             Ok(())
                         } else {
-                            Err(Error)
+                            Err(E::unexpected())
                         }
                     }
 
-                    fn nonnegative(&mut self, n: u64) -> Result<()> {
+                    fn nonnegative(&mut self, n: u64) -> Result<(), E> {
                         if n <= $ty::max_value() as u64 {
                             self.out = Some(n as $ty);
                             Ok(())
                         } else {
-                            Err(Error)
+                            Err(E::unexpected())
                         }
                     }
                 }
@@ -87,15 +91,18 @@ signed!(isize);
 
 macro_rules! unsigned {
     ($ty:ident) => {
-        impl Deserialize for $ty {
-            fn begin(out: &mut Option<Self>) -> &mut dyn Visitor {
-                impl Visitor for Place<$ty> {
-                    fn nonnegative(&mut self, n: u64) -> Result<()> {
+        impl<E> Deserialize<E> for $ty
+        where
+            E: VisitorError,
+        {
+            fn begin(out: &mut Option<Self>) -> &mut dyn Visitor<E> {
+                impl<E: VisitorError> Visitor<E> for Place<$ty> {
+                    fn nonnegative(&mut self, n: u64) -> Result<(), E> {
                         if n <= $ty::max_value() as u64 {
                             self.out = Some(n as $ty);
                             Ok(())
                         } else {
-                            Err(Error)
+                            Err(E::unexpected())
                         }
                     }
                 }
@@ -112,20 +119,20 @@ unsigned!(usize);
 
 macro_rules! float {
     ($ty:ident) => {
-        impl Deserialize for $ty {
-            fn begin(out: &mut Option<Self>) -> &mut dyn Visitor {
-                impl Visitor for Place<$ty> {
-                    fn negative(&mut self, n: i64) -> Result<()> {
+        impl<E: VisitorError> Deserialize<E> for $ty {
+            fn begin(out: &mut Option<Self>) -> &mut dyn Visitor<E> {
+                impl<E: VisitorError> Visitor<E> for Place<$ty> {
+                    fn negative(&mut self, n: i64) -> Result<(), E> {
                         self.out = Some(n as $ty);
                         Ok(())
                     }
 
-                    fn nonnegative(&mut self, n: u64) -> Result<()> {
+                    fn nonnegative(&mut self, n: u64) -> Result<(), E> {
                         self.out = Some(n as $ty);
                         Ok(())
                     }
 
-                    fn float(&mut self, n: f64) -> Result<()> {
+                    fn float(&mut self, n: f64) -> Result<(), E> {
                         self.out = Some(n as $ty);
                         Ok(())
                     }
@@ -138,52 +145,52 @@ macro_rules! float {
 float!(f32);
 float!(f64);
 
-impl<T: Deserialize> Deserialize for Box<T> {
-    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor {
-        impl<T: Deserialize> Visitor for Place<Box<T>> {
-            fn null(&mut self) -> Result<()> {
+impl<E: VisitorError, T: Deserialize<E>> Deserialize<E> for Box<T> {
+    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor<E> {
+        impl<E: VisitorError, T: Deserialize<E>> Visitor<E> for Place<Box<T>> {
+            fn null(&mut self) -> Result<(), E> {
                 let mut out = None;
                 Deserialize::begin(&mut out).null()?;
                 self.out = Some(Box::new(out.unwrap()));
                 Ok(())
             }
 
-            fn boolean(&mut self, b: bool) -> Result<()> {
+            fn boolean(&mut self, b: bool) -> Result<(), E> {
                 let mut out = None;
                 Deserialize::begin(&mut out).boolean(b)?;
                 self.out = Some(Box::new(out.unwrap()));
                 Ok(())
             }
 
-            fn string(&mut self, s: &str) -> Result<()> {
+            fn string(&mut self, s: &str) -> Result<(), E> {
                 let mut out = None;
                 Deserialize::begin(&mut out).string(s)?;
                 self.out = Some(Box::new(out.unwrap()));
                 Ok(())
             }
 
-            fn negative(&mut self, n: i64) -> Result<()> {
+            fn negative(&mut self, n: i64) -> Result<(), E> {
                 let mut out = None;
                 Deserialize::begin(&mut out).negative(n)?;
                 self.out = Some(Box::new(out.unwrap()));
                 Ok(())
             }
 
-            fn nonnegative(&mut self, n: u64) -> Result<()> {
+            fn nonnegative(&mut self, n: u64) -> Result<(), E> {
                 let mut out = None;
                 Deserialize::begin(&mut out).nonnegative(n)?;
                 self.out = Some(Box::new(out.unwrap()));
                 Ok(())
             }
 
-            fn float(&mut self, n: f64) -> Result<()> {
+            fn float(&mut self, n: f64) -> Result<(), E> {
                 let mut out = None;
                 Deserialize::begin(&mut out).float(n)?;
                 self.out = Some(Box::new(out.unwrap()));
                 Ok(())
             }
 
-            fn seq(&mut self) -> Result<Box<dyn Seq + '_>> {
+            fn seq(&mut self) -> Result<Box<dyn Seq<E> + '_>, E> {
                 let mut value = NonuniqueBox::new(None);
                 let ptr = unsafe { extend_lifetime!(&mut *value as &mut Option<T>) };
                 Ok(Box::new(BoxSeq {
@@ -193,7 +200,7 @@ impl<T: Deserialize> Deserialize for Box<T> {
                 }))
             }
 
-            fn map(&mut self) -> Result<Box<dyn Map + '_>> {
+            fn map(&mut self) -> Result<Box<dyn Map<E> + '_>, E> {
                 let mut value = NonuniqueBox::new(None);
                 let ptr = unsafe { extend_lifetime!(&mut *value as &mut Option<T>) };
                 Ok(Box::new(BoxMap {
@@ -204,25 +211,25 @@ impl<T: Deserialize> Deserialize for Box<T> {
             }
         }
 
-        struct BoxSeq<'a, T: 'a> {
+        struct BoxSeq<'a, E, T: 'a> {
             out: &'a mut Option<Box<T>>,
             value: NonuniqueBox<Option<T>>,
             // May borrow from self.value, so must drop first.
-            seq: ManuallyDrop<Box<dyn Seq + 'a>>,
+            seq: ManuallyDrop<Box<dyn Seq<E> + 'a>>,
         }
 
-        impl<'a, T: 'a> Drop for BoxSeq<'a, T> {
+        impl<'a, E, T: 'a> Drop for BoxSeq<'a, E, T> {
             fn drop(&mut self) {
                 unsafe { ManuallyDrop::drop(&mut self.seq) }
             }
         }
 
-        impl<'a, T: Deserialize> Seq for BoxSeq<'a, T> {
-            fn element(&mut self) -> Result<&mut dyn Visitor> {
+        impl<'a, E: VisitorError, T: Deserialize<E>> Seq<E> for BoxSeq<'a, E, T> {
+            fn element(&mut self) -> Result<&mut dyn Visitor<E>, E> {
                 self.seq.element()
             }
 
-            fn finish(&mut self) -> Result<()> {
+            fn finish(&mut self) -> Result<(), E> {
                 self.seq.finish()?;
                 *self.seq = Box::new(Ignore);
                 *self.out = Some(Box::new(self.value.take().unwrap()));
@@ -230,25 +237,25 @@ impl<T: Deserialize> Deserialize for Box<T> {
             }
         }
 
-        struct BoxMap<'a, T: 'a> {
+        struct BoxMap<'a, E, T: 'a> {
             out: &'a mut Option<Box<T>>,
             value: NonuniqueBox<Option<T>>,
             // May borrow from self.value, so must drop first.
-            map: ManuallyDrop<Box<dyn Map + 'a>>,
+            map: ManuallyDrop<Box<dyn Map<E> + 'a>>,
         }
 
-        impl<'a, T: 'a> Drop for BoxMap<'a, T> {
+        impl<'a, E, T: 'a> Drop for BoxMap<'a, E, T> {
             fn drop(&mut self) {
                 unsafe { ManuallyDrop::drop(&mut self.map) }
             }
         }
 
-        impl<'a, T: Deserialize> Map for BoxMap<'a, T> {
-            fn key(&mut self, k: &str) -> Result<&mut dyn Visitor> {
+        impl<'a, E: VisitorError, T: Deserialize<E>> Map<E> for BoxMap<'a, E, T> {
+            fn key(&mut self, k: &str) -> Result<&mut dyn Visitor<E>, E> {
                 self.map.key(k)
             }
 
-            fn finish(&mut self) -> Result<()> {
+            fn finish(&mut self) -> Result<(), E> {
                 self.map.finish()?;
                 *self.map = Box::new(Ignore);
                 *self.out = Some(Box::new(self.value.take().unwrap()));
@@ -260,49 +267,49 @@ impl<T: Deserialize> Deserialize for Box<T> {
     }
 }
 
-impl<T: Deserialize> Deserialize for Option<T> {
+impl<E: VisitorError, T: Deserialize<E>> Deserialize<E> for Option<T> {
     #[inline]
     fn default() -> Option<Self> {
         Some(None)
     }
-    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor {
-        impl<T: Deserialize> Visitor for Place<Option<T>> {
-            fn null(&mut self) -> Result<()> {
+    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor<E> {
+        impl<E: VisitorError, T: Deserialize<E>> Visitor<E> for Place<Option<T>> {
+            fn null(&mut self) -> Result<(), E> {
                 self.out = Some(None);
                 Ok(())
             }
 
-            fn boolean(&mut self, b: bool) -> Result<()> {
+            fn boolean(&mut self, b: bool) -> Result<(), E> {
                 self.out = Some(None);
                 Deserialize::begin(self.out.as_mut().unwrap()).boolean(b)
             }
 
-            fn string(&mut self, s: &str) -> Result<()> {
+            fn string(&mut self, s: &str) -> Result<(), E> {
                 self.out = Some(None);
                 Deserialize::begin(self.out.as_mut().unwrap()).string(s)
             }
 
-            fn negative(&mut self, n: i64) -> Result<()> {
+            fn negative(&mut self, n: i64) -> Result<(), E> {
                 self.out = Some(None);
                 Deserialize::begin(self.out.as_mut().unwrap()).negative(n)
             }
 
-            fn nonnegative(&mut self, n: u64) -> Result<()> {
+            fn nonnegative(&mut self, n: u64) -> Result<(), E> {
                 self.out = Some(None);
                 Deserialize::begin(self.out.as_mut().unwrap()).nonnegative(n)
             }
 
-            fn float(&mut self, n: f64) -> Result<()> {
+            fn float(&mut self, n: f64) -> Result<(), E> {
                 self.out = Some(None);
                 Deserialize::begin(self.out.as_mut().unwrap()).float(n)
             }
 
-            fn seq(&mut self) -> Result<Box<dyn Seq + '_>> {
+            fn seq(&mut self) -> Result<Box<dyn Seq<E> + '_>, E> {
                 self.out = Some(None);
                 Deserialize::begin(self.out.as_mut().unwrap()).seq()
             }
 
-            fn map(&mut self) -> Result<Box<dyn Map + '_>> {
+            fn map(&mut self) -> Result<Box<dyn Map<E> + '_>, E> {
                 self.out = Some(None);
                 Deserialize::begin(self.out.as_mut().unwrap()).map()
             }
@@ -312,10 +319,15 @@ impl<T: Deserialize> Deserialize for Option<T> {
     }
 }
 
-impl<A: Deserialize, B: Deserialize> Deserialize for (A, B) {
-    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor {
-        impl<A: Deserialize, B: Deserialize> Visitor for Place<(A, B)> {
-            fn seq(&mut self) -> Result<Box<dyn Seq + '_>> {
+impl<E, A, B> Deserialize<E> for (A, B)
+where
+    E: VisitorError,
+    A: Deserialize<E>,
+    B: Deserialize<E>,
+{
+    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor<E> {
+        impl<E: VisitorError, A: Deserialize<E>, B: Deserialize<E>> Visitor<E> for Place<(A, B)> {
+            fn seq(&mut self) -> Result<Box<dyn Seq<E> + '_>, E> {
                 Ok(Box::new(TupleBuilder {
                     out: &mut self.out,
                     tuple: (None, None),
@@ -328,23 +340,28 @@ impl<A: Deserialize, B: Deserialize> Deserialize for (A, B) {
             tuple: (Option<A>, Option<B>),
         }
 
-        impl<'a, A: Deserialize, B: Deserialize> Seq for TupleBuilder<'a, A, B> {
-            fn element(&mut self) -> Result<&mut dyn Visitor> {
+        impl<'a, E, A, B> Seq<E> for TupleBuilder<'a, A, B>
+        where
+            E: VisitorError,
+            A: Deserialize<E>,
+            B: Deserialize<E>,
+        {
+            fn element(&mut self) -> Result<&mut dyn Visitor<E>, E> {
                 if self.tuple.0.is_none() {
                     Ok(Deserialize::begin(&mut self.tuple.0))
                 } else if self.tuple.1.is_none() {
                     Ok(Deserialize::begin(&mut self.tuple.1))
                 } else {
-                    Err(Error)
+                    Err(E::unexpected())
                 }
             }
 
-            fn finish(&mut self) -> Result<()> {
+            fn finish(&mut self) -> Result<(), E> {
                 if let (Some(a), Some(b)) = (self.tuple.0.take(), self.tuple.1.take()) {
                     *self.out = Some((a, b));
                     Ok(())
                 } else {
-                    Err(Error)
+                    Err(E::unexpected())
                 }
             }
         }
@@ -353,10 +370,10 @@ impl<A: Deserialize, B: Deserialize> Deserialize for (A, B) {
     }
 }
 
-impl<T: Deserialize> Deserialize for Vec<T> {
-    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor {
-        impl<T: Deserialize> Visitor for Place<Vec<T>> {
-            fn seq(&mut self) -> Result<Box<dyn Seq + '_>> {
+impl<E: VisitorError, T: Deserialize<E>> Deserialize<E> for Vec<T> {
+    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor<E> {
+        impl<E: VisitorError, T: Deserialize<E>> Visitor<E> for Place<Vec<T>> {
+            fn seq(&mut self) -> Result<Box<dyn Seq<E> + '_>, E> {
                 Ok(Box::new(VecBuilder {
                     out: &mut self.out,
                     vec: Vec::new(),
@@ -379,13 +396,13 @@ impl<T: Deserialize> Deserialize for Vec<T> {
             }
         }
 
-        impl<'a, T: Deserialize> Seq for VecBuilder<'a, T> {
-            fn element(&mut self) -> Result<&mut dyn Visitor> {
+        impl<'a, E, T: Deserialize<E>> Seq<E> for VecBuilder<'a, T> {
+            fn element(&mut self) -> Result<&mut dyn Visitor<E>, E> {
                 self.shift();
                 Ok(Deserialize::begin(&mut self.element))
             }
 
-            fn finish(&mut self) -> Result<()> {
+            fn finish(&mut self) -> Result<(), E> {
                 self.shift();
                 *self.out = Some(mem::replace(&mut self.vec, Vec::new()));
                 Ok(())
@@ -397,20 +414,22 @@ impl<T: Deserialize> Deserialize for Vec<T> {
 }
 
 #[cfg(feature = "std")]
-impl<K, V, H> Deserialize for HashMap<K, V, H>
+impl<E, K, V, H> Deserialize<E> for HashMap<K, V, H>
 where
     K: FromStr + Hash + Eq,
-    V: Deserialize,
+    V: Deserialize<E>,
     H: BuildHasher + Default,
+    E: VisitorError,
 {
-    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor {
-        impl<K, V, H> Visitor for Place<HashMap<K, V, H>>
+    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor<E> {
+        impl<E, K, V, H> Visitor<E> for Place<HashMap<K, V, H>>
         where
             K: FromStr + Hash + Eq,
-            V: Deserialize,
+            V: Deserialize<E>,
             H: BuildHasher + Default,
+            E: VisitorError,
         {
-            fn map(&mut self) -> Result<Box<dyn Map + '_>> {
+            fn map(&mut self) -> Result<Box<dyn Map<E> + '_>, E> {
                 Ok(Box::new(MapBuilder {
                     out: &mut self.out,
                     map: HashMap::with_hasher(H::default()),
@@ -435,22 +454,23 @@ where
             }
         }
 
-        impl<'a, K, V, H> Map for MapBuilder<'a, K, V, H>
+        impl<'a, E, K, V, H> Map<E> for MapBuilder<'a, K, V, H>
         where
             K: FromStr + Hash + Eq,
-            V: Deserialize,
+            V: Deserialize<E>,
             H: BuildHasher + Default,
+            E: VisitorError,
         {
-            fn key(&mut self, k: &str) -> Result<&mut dyn Visitor> {
+            fn key(&mut self, k: &str) -> Result<&mut dyn Visitor<E>, E> {
                 self.shift();
                 self.key = Some(match K::from_str(k) {
                     Ok(key) => key,
-                    Err(_) => return Err(Error),
+                    Err(_) => return Err(E::unexpected()),
                 });
                 Ok(Deserialize::begin(&mut self.value))
             }
 
-            fn finish(&mut self) -> Result<()> {
+            fn finish(&mut self) -> Result<(), E> {
                 self.shift();
                 let substitute = HashMap::with_hasher(H::default());
                 *self.out = Some(mem::replace(&mut self.map, substitute));
@@ -462,10 +482,15 @@ where
     }
 }
 
-impl<K: FromStr + Ord, V: Deserialize> Deserialize for BTreeMap<K, V> {
-    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor {
-        impl<K: FromStr + Ord, V: Deserialize> Visitor for Place<BTreeMap<K, V>> {
-            fn map(&mut self) -> Result<Box<dyn Map + '_>> {
+impl<E: VisitorError, K: FromStr + Ord, V: Deserialize<E>> Deserialize<E> for BTreeMap<K, V> {
+    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor<E> {
+        impl<E, K, V> Visitor<E> for Place<BTreeMap<K, V>>
+        where
+            K: FromStr + Ord,
+            V: Deserialize<E>,
+            E: VisitorError,
+        {
+            fn map(&mut self) -> Result<Box<dyn Map<E> + '_>, E> {
                 Ok(Box::new(MapBuilder {
                     out: &mut self.out,
                     map: BTreeMap::new(),
@@ -490,17 +515,22 @@ impl<K: FromStr + Ord, V: Deserialize> Deserialize for BTreeMap<K, V> {
             }
         }
 
-        impl<'a, K: FromStr + Ord, V: Deserialize> Map for MapBuilder<'a, K, V> {
-            fn key(&mut self, k: &str) -> Result<&mut dyn Visitor> {
+        impl<'a, E: VisitorError, K, V> Map<E> for MapBuilder<'a, K, V>
+        where
+            E: VisitorError,
+            K: FromStr + Ord,
+            V: Deserialize<E>,
+        {
+            fn key(&mut self, k: &str) -> Result<&mut dyn Visitor<E>, E> {
                 self.shift();
                 self.key = Some(match K::from_str(k) {
                     Ok(key) => key,
-                    Err(_) => return Err(Error),
+                    Err(_) => return Err(E::unexpected()),
                 });
                 Ok(Deserialize::begin(&mut self.value))
             }
 
-            fn finish(&mut self) -> Result<()> {
+            fn finish(&mut self) -> Result<(), E> {
                 self.shift();
                 *self.out = Some(mem::replace(&mut self.map, BTreeMap::new()));
                 Ok(())

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -190,7 +190,8 @@ use alloc::boxed::Box;
 /// Trait for data structures that can be deserialized from a JSON string.
 ///
 /// [Refer to the module documentation for examples.][crate::de]
-pub trait Deserialize<E = Error>: Sized {
+pub trait Deserialize: Sized {
+    type Error: VisitorError;
     /// The only correct implementation of this method is:
     ///
     /// ```rust
@@ -207,7 +208,7 @@ pub trait Deserialize<E = Error>: Sized {
     /// }
     /// # }
     /// ```
-    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor<E>;
+    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor<Self::Error>;
 
     // Not public API. This method is only intended for Option<T>, should not
     // need to be implemented outside of this crate.

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -184,12 +184,13 @@
 
 mod impls;
 
+use crate::error::Error;
 use alloc::boxed::Box;
 
 /// Trait for data structures that can be deserialized from a JSON string.
 ///
 /// [Refer to the module documentation for examples.][crate::de]
-pub trait Deserialize<E>: Sized {
+pub trait Deserialize<E = Error>: Sized {
     /// The only correct implementation of this method is:
     ///
     /// ```rust
@@ -224,7 +225,7 @@ pub trait VisitorError: 'static {
 /// Trait that can write data into an output place.
 ///
 /// [Refer to the module documentation for examples.][crate::de]
-pub trait Visitor<E: VisitorError> {
+pub trait Visitor<E: VisitorError = Error> {
     fn null(&mut self) -> Result<(), E> {
         Err(E::unexpected())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,19 @@
 use core::fmt::{self, Display};
 
+use crate::de::VisitorError;
+
 /// Error type when deserialization fails.
 ///
 /// Miniserde errors contain no information about what went wrong. **If you need
 /// more than no information, use Serde.**
 #[derive(Copy, Clone, Debug)]
 pub struct Error;
+
+impl VisitorError for Error {
+    fn unexpected() -> Self {
+        Self
+    }
+}
 
 /// Result type returned by deserialization functions.
 pub type Result<T> = core::result::Result<T, Error>;

--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -1,9 +1,8 @@
-use crate::de::{Map, Seq, Visitor};
-use crate::error::Result;
+use crate::de::{Map, Seq, Visitor, VisitorError};
 use alloc::boxed::Box;
 
-impl dyn Visitor {
-    pub fn ignore() -> &'static mut dyn Visitor {
+impl<E: VisitorError> dyn Visitor<E> {
+    pub fn ignore() -> &'static mut dyn Visitor<E> {
         static mut IGNORE: Ignore = Ignore;
         unsafe { &mut IGNORE }
         //
@@ -21,56 +20,56 @@ impl dyn Visitor {
 
 pub(crate) struct Ignore;
 
-impl Visitor for Ignore {
-    fn null(&mut self) -> Result<()> {
+impl<E: VisitorError + 'static> Visitor<E> for Ignore {
+    fn null(&mut self) -> Result<(), E> {
         Ok(())
     }
 
-    fn boolean(&mut self, _b: bool) -> Result<()> {
+    fn boolean(&mut self, _b: bool) -> Result<(), E> {
         Ok(())
     }
 
-    fn string(&mut self, _s: &str) -> Result<()> {
+    fn string(&mut self, _s: &str) -> Result<(), E> {
         Ok(())
     }
 
-    fn negative(&mut self, _n: i64) -> Result<()> {
+    fn negative(&mut self, _n: i64) -> Result<(), E> {
         Ok(())
     }
 
-    fn nonnegative(&mut self, _n: u64) -> Result<()> {
+    fn nonnegative(&mut self, _n: u64) -> Result<(), E> {
         Ok(())
     }
 
-    fn float(&mut self, _n: f64) -> Result<()> {
+    fn float(&mut self, _n: f64) -> Result<(), E> {
         Ok(())
     }
 
-    fn seq(&mut self) -> Result<Box<dyn Seq + '_>> {
+    fn seq(&mut self) -> Result<Box<dyn Seq<E> + '_>, E> {
         Ok(Box::new(Ignore))
     }
 
-    fn map(&mut self) -> Result<Box<dyn Map + '_>> {
+    fn map(&mut self) -> Result<Box<dyn Map<E> + '_>, E> {
         Ok(Box::new(Ignore))
     }
 }
 
-impl Seq for Ignore {
-    fn element(&mut self) -> Result<&mut dyn Visitor> {
-        Ok(<dyn Visitor>::ignore())
+impl<E: VisitorError + 'static> Seq<E> for Ignore {
+    fn element(&mut self) -> Result<&mut dyn Visitor<E>, E> {
+        Ok(<dyn Visitor<E>>::ignore())
     }
 
-    fn finish(&mut self) -> Result<()> {
+    fn finish(&mut self) -> Result<(), E> {
         Ok(())
     }
 }
 
-impl Map for Ignore {
-    fn key(&mut self, _k: &str) -> Result<&mut dyn Visitor> {
-        Ok(<dyn Visitor>::ignore())
+impl<E: VisitorError + 'static> Map<E> for Ignore {
+    fn key(&mut self, _k: &str) -> Result<&mut dyn Visitor<E>, E> {
+        Ok(<dyn Visitor<E>>::ignore())
     }
 
-    fn finish(&mut self) -> Result<()> {
+    fn finish(&mut self) -> Result<(), E> {
         Ok(())
     }
 }

--- a/src/json/de.rs
+++ b/src/json/de.rs
@@ -26,10 +26,10 @@ use core::str;
 ///     Ok(())
 /// }
 /// ```
-pub fn from_str<T: Deserialize<E>, E: VisitorError>(j: &str) -> Result<T, E> {
+pub fn from_str<T: Deserialize>(j: &str) -> Result<T, T::Error> {
     let mut out = None;
     from_str_impl(j, T::begin(&mut out))?;
-    out.ok_or(E::unexpected())
+    out.ok_or(T::Error::unexpected())
 }
 
 struct Deserializer<'a, 'b, E> {

--- a/src/json/de.rs
+++ b/src/json/de.rs
@@ -26,7 +26,7 @@ use core::str;
 ///     Ok(())
 /// }
 /// ```
-pub fn from_str<E: VisitorError, T: Deserialize<E>>(j: &str) -> Result<T, E> {
+pub fn from_str<T: Deserialize<E>, E: VisitorError>(j: &str) -> Result<T, E> {
     let mut out = None;
     from_str_impl(j, T::begin(&mut out))?;
     out.ok_or(E::unexpected())

--- a/src/json/value.rs
+++ b/src/json/value.rs
@@ -58,8 +58,9 @@ impl Serialize for Value {
     }
 }
 
-impl<E: VisitorError> Deserialize<E> for Value {
-    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor<E> {
+impl Deserialize for Value {
+    type Error = crate::Error;
+    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor<Self::Error> {
         impl<E: VisitorError> Visitor<E> for Place<Value> {
             fn null(&mut self) -> Result<(), E> {
                 self.out = Some(Value::Null);


### PR DESCRIPTION
Make error an asociated error type to the `Deserialize` trait.

This seems like a dead end, since it requires Seq and Map to have asociated error types too. It may not be desirable either, since one may want to provide different implementation for custom types, with different error types.

This option would have been usefull for a `MapErr` type to wrap `impl Deserialize` types easily.
